### PR TITLE
Update link to OpenAI models in Quickstart

### DIFF
--- a/quick_start/02_OpenAI_getting_started.ipynb
+++ b/quick_start/02_OpenAI_getting_started.ipynb
@@ -202,7 +202,7 @@
         "* text-curie-001\n",
         "* text-davinci-003  \n",
         "\n",
-        "[Azure OpenAI models](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/concepts/models])  \n",
+        "[Azure OpenAI models](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/concepts/models)  \n",
         "![](images/a-b-c-d-models-reduced.jpg)  \n",
         "\n",
         "| | Similarity embedding | Text search embedding | Code Search Embedding |\n",


### PR DESCRIPTION
The original link is throwing a 404, so I removed the extra character.